### PR TITLE
Temporary homepage

### DIFF
--- a/lib/scrawled_web/templates/layout/app.html.heex
+++ b/lib/scrawled_web/templates/layout/app.html.heex
@@ -1,5 +1,3 @@
-<main class="container">
-  <p class="alert alert-info" role="alert"><%= get_flash(@conn, :info) %></p>
-  <p class="alert alert-danger" role="alert"><%= get_flash(@conn, :error) %></p>
+<main class="container mx-auto">
   <%= @inner_content %>
 </main>

--- a/lib/scrawled_web/templates/layout/root.html.heex
+++ b/lib/scrawled_web/templates/layout/root.html.heex
@@ -10,21 +10,6 @@
     <script defer phx-track-static type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}></script>
   </head>
   <body>
-    <header>
-      <section class="container">
-        <nav>
-          <ul>
-            <li><a href="https://hexdocs.pm/phoenix/overview.html">Get Started</a></li>
-            <%= if function_exported?(Routes, :live_dashboard_path, 2) do %>
-              <li><%= link "LiveDashboard", to: Routes.live_dashboard_path(@conn, :home) %></li>
-            <% end %>
-          </ul>
-        </nav>
-        <a href="https://phoenixframework.org/" class="phx-logo">
-          <img src={Routes.static_path(@conn, "/images/phoenix.png")} alt="Phoenix Framework Logo"/>
-        </a>
-      </section>
-    </header>
     <%= @inner_content %>
   </body>
 </html>

--- a/lib/scrawled_web/templates/page/index.html.heex
+++ b/lib/scrawled_web/templates/page/index.html.heex
@@ -1,41 +1,6 @@
-<section class="phx-hero">
-  <h1><%= gettext "Welcome to %{name}!", name: "Phoenix" %></h1>
-  <p>Peace of mind from prototype to production</p>
-</section>
-
-<section class="row">
-  <article class="column">
-    <h2>Resources</h2>
-    <ul>
-      <li>
-        <a href="https://hexdocs.pm/phoenix/overview.html">Guides &amp; Docs</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix">Source</a>
-      </li>
-      <li>
-        <a href="https://github.com/phoenixframework/phoenix/blob/v1.6/CHANGELOG.md">v1.6 Changelog</a>
-      </li>
-    </ul>
-  </article>
-  <article class="column">
-    <h2>Help</h2>
-    <ul>
-      <li>
-        <a href="https://elixirforum.com/c/phoenix-forum">Forum</a>
-      </li>
-      <li>
-        <a href="https://web.libera.chat/#elixir">#elixir on Libera Chat (IRC)</a>
-      </li>
-      <li>
-        <a href="https://twitter.com/elixirphoenix">Twitter @elixirphoenix</a>
-      </li>
-      <li>
-        <a href="https://elixir-slackin.herokuapp.com/">Elixir on Slack</a>
-      </li>
-      <li>
-        <a href="https://discord.gg/elixir">Elixir on Discord</a>
-      </li>
-    </ul>
-  </article>
+<section class="text-center grid grid-cols-1 h-screen content-center">
+  <h1 class="text-2xl">Michael Lee</h1>
+  <h2 class="text-sm font-light">Software Engineering Manager</h2>
+  <br>
+  <a href="mailto:michael@mrlee.io" class="text-sky-500">michael@mrlee.io</a>
 </section>

--- a/test/scrawled_web/controllers/page_controller_test.exs
+++ b/test/scrawled_web/controllers/page_controller_test.exs
@@ -3,6 +3,6 @@ defmodule ScrawledWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Michael Lee"
   end
 end


### PR DESCRIPTION
Modify the default index page to include basic contact details.

This work is in prepartion of adding a deployment pipeline; I don't want
to expose the default Pheonix page.
