### PR TITLE
Elixir 1.14.0

### DIFF
--- a/.github/workflows/credo.yml
+++ b/.github/workflows/credo.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         otp: ['25.0.4']
-        elixir: ['1.13.4']
+        elixir: ['1.14.0']
     steps:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         otp: ['25.0.4']
-        elixir: ['1.13.4']
+        elixir: ['1.14.0']
     services:
       postgres:
         image: postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #   - https://pkgs.org/ - resource for finding needed packages
 #   - Ex: hexpm/elixir:1.13.4-erlang-25.0.4-debian-bullseye-20210902-slim
 #
-ARG ELIXIR_VERSION=1.13.4
+ARG ELIXIR_VERSION=1.14.0
 ARG OTP_VERSION=25.0.4
 ARG DEBIAN_VERSION=bullseye-20220801-slim
 
@@ -23,14 +23,14 @@ FROM ${BUILDER_IMAGE} as builder
 
 # install build dependencies
 RUN apt-get update -y && apt-get install -y build-essential git \
-    && apt-get clean && rm -f /var/lib/apt/lists/*_*
+  && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # prepare build dir
 WORKDIR /app
 
 # install hex + rebar
 RUN mix local.hex --force && \
-    mix local.rebar --force
+  mix local.rebar --force
 
 # set build ENV
 ENV MIX_ENV="prod"


### PR DESCRIPTION
Add configuration options for Elixir v1.14.0 and use the latest version for production, static analysis, and testing.
